### PR TITLE
グローバル空間のControllerに対応する

### DIFF
--- a/src/DiiWebApplication.php
+++ b/src/DiiWebApplication.php
@@ -59,13 +59,23 @@ class DiiWebApplication extends \CWebApplication
             if (is_file($classFile)) {
                 if (! class_exists($className, false)) {
                     include_once $classFile;
-
                 }
-                $namespacedClassName = sprintf('application\\%s%s', ucfirst($id), 'Controller');
+
+                $controllerName = ucfirst($id) . 'Controller';
+
+                $namespacedClassName = 'application\\' . $controllerName;
                 if (class_exists($namespacedClassName, false) && is_subclass_of($namespacedClassName, \CController::class)) {
                     $id[0] = strtolower($id[0]);
                     return [
                         $this->newInstance($namespacedClassName, $controllerID . $id, $owner === $this ? null : $owner),
+                        $this->parseActionParams($route),
+                    ];
+                }
+
+                if (class_exists($controllerName, false) && is_subclass_of($controllerName, \CController::class)) {
+                    $id[0] = strtolower($id[0]);
+                    return [
+                        $this->newInstance($controllerName, $controllerID . $id, $owner === $this ? null : $owner),
                         $this->parseActionParams($route),
                     ];
                 }


### PR DESCRIPTION
`DiiWebApplication::createController()`は実行されるYiiのモジュールに`$controllerNamespace`が未定義の場合は、一律で`application\`という名前空間内のControllerを探索する実装になっています。

グローバル空間のControllerクラスが見つけられないため、名前空間なしでControllerクラスを探索する処理を追加しました。