### PR TITLE
override CConsoleCommandRunner::createCommand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "classmap": [
           "vendor/yiisoft/yii/framework/base/",
-          "vendor/yiisoft/yii/framework/web/"
+          "vendor/yiisoft/yii/framework/web/",
+          "vendor/yiisoft/yii/framework/console/"
     ]
   },
   "license": "MIT",

--- a/demo/composer.json
+++ b/demo/composer.json
@@ -7,9 +7,12 @@
     "autoload": {
         "psr-4": {
             "Vendor\\Hello\\": "src/App",
-            "Koriym\\Dii\\Module\\": "src/Module"
+            "Koriym\\Dii\\Module\\": "src/Module",
+            "Vendor\\App\\": "public/protected"
         },
         "classmap": [
+            "public/protected/controllers/",
+            "public/protected/commands/",
             "vendor/yiisoft/yii/framework/base",
             "vendor/yiisoft/yii/framework/caching",
             "vendor/yiisoft/yii/framework/collections",

--- a/demo/public/command.php
+++ b/demo/public/command.php
@@ -1,0 +1,10 @@
+<?php
+
+// include Yii bootstrap file
+require dirname(__DIR__) . '/vendor/autoload.php';
+spl_autoload_unregister([YiiBase::class, 'autoload']);
+
+$config = __DIR__ . '/protected/config/main.php';
+
+// create a Console application instance and run
+\Koriym\Dii\Dii::createConsoleApplication($config)->run();

--- a/demo/public/protected/commands/NamespacedCommand.php
+++ b/demo/public/protected/commands/NamespacedCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Vendor\App\Command;
+
+use Ray\Di\Di\Inject;
+use Koriym\Dii\Injectable;
+use Vendor\Hello\FooInterface;
+
+class NamespacedCommand extends \CConsoleCommand implements Injectable
+{
+    /**
+     * @var FooInterface
+     */
+    private $foo;
+
+    /**
+     * @Inject
+     */
+    public function setFoo(FooInterface $foo) : void
+    {
+        $this->foo = $foo;
+    }
+
+    public function actionIndex() : void
+    {
+        echo  $this->foo->get() . PHP_EOL;
+        echo ' This is namespaced command.' . PHP_EOL;
+    }
+}

--- a/demo/public/protected/commands/SampleCommand.php
+++ b/demo/public/protected/commands/SampleCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+use Ray\Di\Di\Inject;
+use Koriym\Dii\Injectable;
+use Vendor\Hello\FooInterface;
+
+class SampleCommand extends \CConsoleCommand implements Injectable
+{
+    /**
+     * @var FooInterface
+     */
+    private $foo;
+
+    /**
+     * @Inject
+     */
+    public function setFoo(FooInterface $foo) : void
+    {
+        $this->foo = $foo;
+    }
+
+    public function actionIndex() : void
+    {
+        echo  $this->foo->get() . PHP_EOL;
+        echo ' This is sample command.' . PHP_EOL;
+    }
+}

--- a/demo/public/protected/config/main.php
+++ b/demo/public/protected/config/main.php
@@ -8,6 +8,7 @@
 return [
     // preloading 'log' component
     'preload' => ['log'],
+    'basePath' => dirname(__DIR__),
     // application components
     'components' => [
         'log' => [
@@ -24,4 +25,9 @@ return [
             ],
         ],
     ],
+    'commandMap' => [
+        'namespaced' => [
+            'class' => \Vendor\App\Command\NamespacedCommand::class
+        ]
+    ]
 ];

--- a/demo/src/Module/AppModule.php
+++ b/demo/src/Module/AppModule.php
@@ -6,12 +6,15 @@ use Ray\Di\AbstractModule;
 use Vendor\Hello\BarInterceptor;
 use Vendor\Hello\Foo;
 use Vendor\Hello\FooInterface;
+use Vendor\App\Command\NamespacedCommand;
 
 class AppModule extends AbstractModule
 {
     protected function configure()
     {
         $this->bind(\SiteController::class);
+        $this->bind(\SampleCommand::class);
+        $this->bind(NamespacedCommand::class);
         $this->bind(FooInterface::class)->to(Foo::class);
         $this->bindInterceptor(
             $this->matcher->any(),

--- a/src/Dii.php
+++ b/src/Dii.php
@@ -44,6 +44,14 @@ class Dii extends YiiBase
         return self::createApplication(DiiWebApplication::class, $config);
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public static function createConsoleApplication($config = null)
+    {
+        return self::createApplication(DiiConsoleApplication::class, $config);
+    }
+
     public static function getGrapher() : Grapher
     {
         $tmpDir = dirname((new \ReflectionClass(AppModule::class))->getFileName()) . '/tmp';

--- a/src/DiiConsoleApplication.php
+++ b/src/DiiConsoleApplication.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Koriym\Dii;
+
+class DiiConsoleApplication extends \CConsoleApplication
+{
+    protected function createCommandRunner()
+    {
+        return new DiiConsoleCommandRunner();
+    }
+}

--- a/src/DiiConsoleCommandRunner.php
+++ b/src/DiiConsoleCommandRunner.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Koriym\Dii;
+
+use CConsoleCommandRunner;
+use Yii;
+
+class DiiConsoleCommandRunner extends CConsoleCommandRunner
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createCommand($name)
+    {
+        $name = strtolower($name);
+
+        $command = null;
+        if (isset($this->commands[$name])) {
+            $command = $this->commands[$name];
+        } else {
+            $commands = array_change_key_case($this->commands);
+            if (isset($commands[$name])) {
+                $command = $commands[$name];
+            }
+        }
+
+        if ($command !== null) {
+            if (is_string($command)) { // class file path or alias
+                if (strpos($command, '/') !== false || strpos($command, '\\') !== false) {
+                    $className = substr(basename($command), 0, -4);
+                    if (! class_exists($className, false)) {
+                        require_once $command;
+                    }
+                } else { // an alias
+                    $className = Yii::import($command);
+                }
+
+                return Yii::createComponent(['class' => $className], $name, $this);
+            }
+            // an array configuration
+            return Yii::createComponent($command, $name, $this);
+        } elseif ($name === 'help') {
+            return new \CHelpCommand('help', $this);
+        }
+
+        return null;
+    }
+}

--- a/src/DiiConsoleCommandRunner.php
+++ b/src/DiiConsoleCommandRunner.php
@@ -35,10 +35,12 @@ class DiiConsoleCommandRunner extends CConsoleCommandRunner
                     $className = Yii::import($command);
                 }
 
-                return Yii::createComponent(['class' => $className], $name, $this);
+                // This line is main difference from parent::createCommand.
+                // Object should be instantiated through `Dii::createComponent`.
+                return Dii::createComponent(['class' => $className], $name, $this);
             }
             // an array configuration
-            return Yii::createComponent($command, $name, $this);
+            return Dii::createComponent($command, $name, $this);
         } elseif ($name === 'help') {
             return new \CHelpCommand('help', $this);
         }


### PR DESCRIPTION
CConsoleCommandRunner::createCommand をオーバーライドし、コマンドのオブジェクト生成にDii::createComponentを利用する

オーバーライドは https://github.com/koriym/dii/compare/master...amashigeseiji:feature/console?expand=1#diff-ee3ecf23abf7f82bdf66265682f06d8360285a40ce46ba587cc18c1791f1cb6bR38 のみです