### PR TITLE
[WIP] modules配下のControllerを読み込み可能にする

### DIFF
--- a/src/ControllerClassResolver.php
+++ b/src/ControllerClassResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii;
+
+use CController;
+
+/**
+ * コントローラー名からクラスを探索してインスタンス化する
+ */
+class ControllerClassResolver
+{
+    /**
+     * @param string $className
+     * @param string $controllerID
+     * @param string $id
+     * @param mixed $owner
+     * @return CController|null
+     */
+    public function __invoke(string $className, string $controllerID, string $id, $owner): ?CController
+    {
+        if (class_exists($className, false) && is_subclass_of($className, CController::class)) {
+            return $this->newInstance($className, $controllerID, $id, $owner);
+        }
+
+        $namespacedClassName = 'application\\' . ucfirst($id) . 'Controller';
+        if (class_exists($namespacedClassName, false) && is_subclass_of($namespacedClassName, CController::class)) {
+            return $this->newInstance($namespacedClassName, $controllerID, $id, $owner);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $className
+     * @param string $controllerId
+     * @param string $id
+     * @param mixed $owner
+     * @return CController
+     */
+    private function newInstance(string $className, string $controllerId, string $id, $owner): CController
+    {
+        $id[0] = strtolower($id[0]);
+        $controllerId .= $id;
+        $isInjectable = in_array(Injectable::class, class_implements($className), true);
+        $controller = $isInjectable ? Dii::getGrapher()->newInstanceArgs($className, [$controllerId, $owner]) : new $className($controllerId, $owner);
+
+        return $controller;
+    }
+}

--- a/src/DiiWebApplication.php
+++ b/src/DiiWebApplication.php
@@ -80,14 +80,6 @@ class DiiWebApplication extends \CWebApplication
                     ];
                 }
 
-                if (class_exists($controllerName, false) && is_subclass_of($controllerName, \CController::class)) {
-                    $id[0] = strtolower($id[0]);
-                    return [
-                        $this->newInstance($controllerName, $controllerID . $id, $owner === $this ? null : $owner),
-                        $this->parseActionParams($route),
-                    ];
-                }
-
                 return null;
             }
             $controllerID .= $id;

--- a/src/DiiWebApplication.php
+++ b/src/DiiWebApplication.php
@@ -61,6 +61,14 @@ class DiiWebApplication extends \CWebApplication
                     include_once $classFile;
                 }
 
+                if (class_exists($className, false) && is_subclass_of($className, \CController::class)) {
+                    $id[0] = strtolower($id[0]);
+                    return [
+                        $this->newInstance($className, $controllerID . $id, $owner === $this ? null : $owner),
+                        $this->parseActionParams($route),
+                    ];
+                }
+
                 $controllerName = ucfirst($id) . 'Controller';
 
                 $namespacedClassName = 'application\\' . $controllerName;


### PR DESCRIPTION
Yiiには`modules/`配下にControllerを配置して`module`単体のアプリケーションとして動かすことができます。
[名前空間化モジュール](https://www.yiiframework.com/doc/guide/1.1/ja/basics.namespace#sec-8)

下記のようにDiiもこのControllerの名前を生成する処理はありますが、後続でこのController名で解決する処理が抜けているため、現状では`modules/`配下のControllerクラスをインスタンス化することができないので、修正しました。

`$className = $owner->controllerNamespace . '\\' . str_replace('/', '\\', $controllerID) . $className;` [DiiWebApplication.php#L56](https://github.com/koriym/dii/blob/master/src/DiiWebApplication.php#L56)

