### PR TITLE
 modules配下のControllerを読み込み可能にする

### DIFF
--- a/src/DiiWebApplication.php
+++ b/src/DiiWebApplication.php
@@ -81,15 +81,6 @@ class DiiWebApplication extends \CWebApplication
                     ];
                 }
 
-                if (class_exists($controllerName, false) && is_subclass_of($controllerName, \CController::class)) {
-                    $id[0] = strtolower($id[0]);
-
-                    return [
-                        $this->newInstance($controllerName, $controllerID . $id, $owner === $this ? null : $owner),
-                        $this->parseActionParams($route),
-                    ];
-                }
-
                 return null;
             }
             $controllerID .= $id;

--- a/src/DiiWebApplication.php
+++ b/src/DiiWebApplication.php
@@ -61,6 +61,14 @@ class DiiWebApplication extends \CWebApplication
                     include_once $classFile;
                 }
 
+                if (class_exists($className, false) && is_subclass_of($className, \CController::class)) {
+                    $id[0] = strtolower($id[0]);
+                    return [
+                        $this->newInstance($className, $controllerID . $id, $owner === $this ? null : $owner),
+                        $this->parseActionParams($route),
+                    ];
+                }
+
                 $controllerName = ucfirst($id) . 'Controller';
 
                 $namespacedClassName = 'application\\' . $controllerName;


### PR DESCRIPTION
Yiiには`modules/`配下にControllerを配置して`module`単体のアプリケーションとして動かすことができます。
[名前空間化モジュール](https://www.yiiframework.com/doc/guide/1.1/ja/basics.namespace#sec-8)

下記のようにDiiもこのControllerの名前を生成する処理はありますが、後続でこのController名で解決する処理が抜けているため、現状では`modules/`配下のControllerクラスをインスタンス化することができません。

`$className = $owner->controllerNamespace . '\\' . str_replace('/', '\\', $controllerID) . $className;` [DiiWebApplication.php#L56](https://github.com/koriym/dii/blob/master/src/DiiWebApplication.php#L56)

# やったこと
- `modules/`配下のControllerクラスをインスタンス化できるように修正 6a5e32abf2793572026f4f95a65e9a8f5cd171c8
- これに伴い #7 も今回追加したロジックで処理できるようになったので削除 96574234002f32a1350e340e08b520a256265601

# 備考
Controllerクラスを探す処理の分離リファクタリングは別のPRで対応します。