### PR TITLE
`Dii::createComponent()`時にインスタンス化するControllerやActionクラスをBindする

### DIFF
--- a/demo/src/Module/AppModule.php
+++ b/demo/src/Module/AppModule.php
@@ -12,9 +12,6 @@ class AppModule extends AbstractModule
 {
     protected function configure()
     {
-        $this->bind(\SiteController::class);
-        $this->bind(\SampleCommand::class);
-        $this->bind(NamespacedCommand::class);
         $this->bind(FooInterface::class)->to(Foo::class);
         $this->bindInterceptor(
             $this->matcher->any(),

--- a/src/Dii.php
+++ b/src/Dii.php
@@ -4,6 +4,7 @@ namespace Koriym\Dii;
 
 use CException;
 use Koriym\Dii\Module\AppModule;
+use Ray\Di\AbstractModule;
 use Ray\Di\Grapher;
 use YiiBase;
 
@@ -14,6 +15,9 @@ class Dii extends YiiBase
 {
     /** @var class-string<ModuleProvider> */
     public static $context = App::class;
+
+    /** @var AbstractModule */
+    private static $module;
 
     /**
      * @param class-string<ModuleProvider> $context
@@ -68,7 +72,18 @@ class Dii extends YiiBase
     {
         $tmpDir = dirname((new \ReflectionClass(AppModule::class))->getFileName()) . '/tmp';
 
-        return new Grapher((new self::$context)(), $tmpDir);
+        return new Grapher(self::getModuleInstance(), $tmpDir);
+    }
+
+    /**
+     * Get singleton instance of Module class
+     */
+    private static function getModuleInstance() : AbstractModule
+    {
+        if (! self::$module instanceof AbstractModule) {
+            self::$module = (new self::$context)();
+        }
+        return self::$module;
     }
 
     /**


### PR DESCRIPTION
`AppModule`で`Controller`や`Action`クラスをBindしなくても良いように、`Dii::createComponent()`時にインスタンス化する`Controller`や`Action`クラスをBindするようにしました。

### やったこと
- 単一のDIコンテナに`Controller`や`Action`クラスをBindできるように、`Grapher`に渡す`Module`クラスのインスタンスをシングルトンで参照できるようにしました。 4fc3d69
- インスタンス化対象の`Controller`や`Action`のインスタンスを`Grapher`がDIコンテナから見つけられなかった場合に、BindしてDIコンテナから再取得するようにしました。 1911a4b
- `AppModule`で`Controller`や`Action`のBindが不要になるのでDemoから削除しました。 80ee1e5