### PR TITLE
Add silent annotation loader

### DIFF
--- a/demo/public/index.php
+++ b/demo/public/index.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 // include Yii bootstrap file
 use Composer\Autoload\ClassLoader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
-use Koriym\Dii\Autoload;
+use Koriym\Dii\SilentAutoload;
 use Koriym\Dii\Dii;
 use Koriym\Dii\Test;
 
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';
-AnnotationRegistry::registerLoader([Autoload::class, 'autoload']);
+AnnotationRegistry::registerLoader([SilentAutoload::class, 'autoload']);
 
 $config = __DIR__ . '/protected/config/main.php';
 

--- a/demo/public/index.php
+++ b/demo/public/index.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 // include Yii bootstrap file
 use Composer\Autoload\ClassLoader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Koriym\Dii\Autoload;
 use Koriym\Dii\Dii;
 use Koriym\Dii\Test;
 
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';
-spl_autoload_unregister([YiiBase::class, 'autoload']);
+AnnotationRegistry::registerLoader([Autoload::class, 'autoload']);
 
 $config = __DIR__ . '/protected/config/main.php';
 

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii;
+
+/**
+ * Silent auto loader
+ *
+ * If the class is not found, no warning will be triggerd.
+ */
+final class Autoload
+{
+    public static function autoload(string $class): bool
+    {
+        $e = error_reporting(E_ALL & ~E_WARNING);
+        $classExists = class_exists($class);
+        error_reporting($e);
+
+        return $classExists;
+    }
+}

--- a/src/SilentAutoload.php
+++ b/src/SilentAutoload.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace Koriym\Dii;
 
+use function class_exists;
+use function error_reporting;
+
+use const E_ALL;
+use const E_WARNING;
+
 /**
  * Silent auto loader
  *
  * If the class is not found, no warning will be triggerd.
  */
-final class Autoload
+final class SilentAutoload
 {
     public static function autoload(string $class): bool
     {

--- a/src/SilentAutoload.php
+++ b/src/SilentAutoload.php
@@ -17,6 +17,13 @@ use const E_WARNING;
  */
 final class SilentAutoload
 {
+    /**
+     * @codeCoverageIgnore
+     */
+    private function __construct()
+    {
+    }
+
     public static function autoload(string $class): bool
     {
         $e = error_reporting(E_ALL & ~E_WARNING);


### PR DESCRIPTION
Suppresses Yii1's autoloader warning when loading annotations.

アノテーション読み込み時の、Yii1のオートローダーのwarningを抑制します。
アプリケーションで"サイレントローダー"を登録します。

See [the example code](https://github.com/koriym/dii/blob/88d1a33baf15db9a4e3abe26ad28e677baf01c33/demo/public/index.php#L13).

