### PR TITLE
Fix generating subdirectory controller id

### DIFF
--- a/src/DiiWebApplication.php
+++ b/src/DiiWebApplication.php
@@ -94,7 +94,7 @@ class DiiWebApplication extends CWebApplication
                     $id[0] = strtolower($id[0]);
 
                     return [
-                        Dii::createComponent($className, $id, $owner === $this ? null : $owner),
+                        Dii::createComponent($className, $controllerID . $id, $owner === $this ? null : $owner),
                         $this->parseActionParams($route),
                     ];
                 }
@@ -106,7 +106,7 @@ class DiiWebApplication extends CWebApplication
                     $id[0] = strtolower($id[0]);
 
                     return [
-                        Dii::createComponent($namespacedClassName, $id, $owner === $this ? null : $owner),
+                        Dii::createComponent($namespacedClassName, $controllerID . $id, $owner === $this ? null : $owner),
                         $this->parseActionParams($route),
                     ];
                 }

--- a/tests/Fake/protected/controllers/NamespacedController.php
+++ b/tests/Fake/protected/controllers/NamespacedController.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace application\controllers;
+
+use CController;
+
+class NamespacedController extends CController
+{
+}

--- a/tests/Fake/protected/controllers/SiteController.php
+++ b/tests/Fake/protected/controllers/SiteController.php
@@ -1,0 +1,5 @@
+<?php
+
+class SiteController extends CController
+{
+}

--- a/tests/Fake/protected/controllers/subdir/SubdirectoryController.php
+++ b/tests/Fake/protected/controllers/subdir/SubdirectoryController.php
@@ -1,0 +1,5 @@
+<?php
+
+class SubdirectoryController extends CController
+{
+}

--- a/tests/Fake/protected/modules/some/SomeModule.php
+++ b/tests/Fake/protected/modules/some/SomeModule.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace application\modules\some;
+
+use CWebModule;
+
+class SomeModule extends CWebModule
+{
+    public $controllerNamespace = '\application\modules\some\controllers';
+}

--- a/tests/Fake/protected/modules/some/controllers/ModuleController.php
+++ b/tests/Fake/protected/modules/some/controllers/ModuleController.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace application\modules\some\controllers;
+
+use CController;
+
+class ModuleController extends CController
+{
+}

--- a/tests/Fake/protected/modules/some/controllers/subdir/SubdirectoryController.php
+++ b/tests/Fake/protected/modules/some/controllers/subdir/SubdirectoryController.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace application\modules\some\controllers\subdir;
+
+use CController;
+
+class SubdirectoryController extends CController
+{
+}

--- a/tests/UnitTest/DiiWebApplicationTest.php
+++ b/tests/UnitTest/DiiWebApplicationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\Dii;
 
+use application\controllers\NamespacedController;
 use CWebApplication;
 use PHPUnit\Framework\TestCase;
 use Yii;
@@ -19,6 +20,11 @@ class DiiWebApplicationTest extends TestCase
     {
         $this->config = [
             'basePath' => dirname(__DIR__) . '/Fake/protected',
+            'controllerMap' => [
+                'namespaced' => [
+                    'class' => NamespacedController::class,
+                ],
+            ],
         ];
         parent::setUp();
     }
@@ -46,6 +52,7 @@ class DiiWebApplicationTest extends TestCase
             [''],
             ['site/foo'],
             ['subdir/subdirectory'],
+            ['namespaced'],
         ];
     }
 }

--- a/tests/UnitTest/DiiWebApplicationTest.php
+++ b/tests/UnitTest/DiiWebApplicationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Koriym\Dii;
 
 use application\controllers\NamespacedController;
+use application\modules\some\SomeModule;
 use CWebApplication;
 use PHPUnit\Framework\TestCase;
 use Yii;
@@ -23,6 +24,11 @@ class DiiWebApplicationTest extends TestCase
             'controllerMap' => [
                 'namespaced' => [
                     'class' => NamespacedController::class,
+                ],
+            ],
+            'modules' => [
+                'some' => [
+                    'class' => SomeModule::class,
                 ],
             ],
         ];
@@ -53,6 +59,8 @@ class DiiWebApplicationTest extends TestCase
             ['site/foo'],
             ['subdir/subdirectory'],
             ['namespaced'],
+            ['some/module'],
+            ['some/subdir/subdirectory'],
         ];
     }
 }

--- a/tests/UnitTest/DiiWebApplicationTest.php
+++ b/tests/UnitTest/DiiWebApplicationTest.php
@@ -18,6 +18,7 @@ class DiiWebApplicationTest extends TestCase
     public function setUp(): void
     {
         $this->config = [
+            'basePath' => dirname(__DIR__) . '/Fake/protected',
         ];
         parent::setUp();
     }
@@ -42,6 +43,9 @@ class DiiWebApplicationTest extends TestCase
     public function routesProvider(): array
     {
         return [
+            [''],
+            ['site/foo'],
+            ['subdir/subdirectory'],
         ];
     }
 }

--- a/tests/UnitTest/DiiWebApplicationTest.php
+++ b/tests/UnitTest/DiiWebApplicationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii;
+
+use CWebApplication;
+use PHPUnit\Framework\TestCase;
+use Yii;
+
+use function dirname;
+
+class DiiWebApplicationTest extends TestCase
+{
+    /** @var string[]|array[] */
+    private $config;
+
+    public function setUp(): void
+    {
+        $this->config = [
+        ];
+        parent::setUp();
+    }
+
+    /**
+     * @dataProvider routesProvider
+     */
+    public function testCreateController(string $route): void
+    {
+        [$diiController, $diiAction] = (new DiiWebApplication($this->config))->createController($route);
+        Yii::setApplication(null);
+        [$yiiController, $yiiAction] = (new CWebApplication($this->config))->createController($route);
+        Yii::setApplication(null);
+
+        $this->assertSame($yiiController->getId(), $diiController->getId());
+        $this->assertSame($yiiAction, $diiAction);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function routesProvider(): array
+    {
+        return [
+        ];
+    }
+}


### PR DESCRIPTION
サブディレクトリに配置されたControllerのID生成処理が https://github.com/koriym/dii/pull/15 の変更により誤った値が設定されるようになっていたため修正しました。

DiiWebApplicationのUnitTestを追加することで正規の仕様を担保します。
UnitTestは`DiiWebApplication`の親クラス`CWebApplication`の`createController()`メソッドと同じ値を生成することを検証します。
Fakeディレクトリ配下に探索対象となるControllerクラスを作成しています。