### PR TITLE
Add Dii::registerSilentAutoLoader()

### DIFF
--- a/demo/public/index.php
+++ b/demo/public/index.php
@@ -3,14 +3,12 @@
 declare(strict_types=1);
 
 // include Yii bootstrap file
-use Composer\Autoload\ClassLoader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
-use Koriym\Dii\SilentAutoload;
 use Koriym\Dii\Dii;
 use Koriym\Dii\Test;
 
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';
-Dii::registerAnnotationLoader();
+Dii::registerAnnotationLoader(); // アノテーションローダーのwarning抑制
+//Dii::registerSilentAutoLoader(); // YiiBase::autoloadのwarning抑制
 
 $config = __DIR__ . '/protected/config/main.php';
 

--- a/src/Dii.php
+++ b/src/Dii.php
@@ -21,10 +21,15 @@ use function assert;
 use function class_exists;
 use function class_implements;
 use function dirname;
+use function error_reporting;
 use function func_get_args;
 use function in_array;
 use function is_callable;
 use function is_string;
+use function spl_autoload_register;
+use function spl_autoload_unregister;
+use const E_ALL;
+use const E_WARNING;
 
 /**
  * Ray.Di powered Yii class
@@ -155,9 +160,26 @@ class Dii extends YiiBase
     /**
      * Register silent annotation loader
      */
-    public static function registerAnnotationLoader()
+    public static function registerAnnotationLoader(): void
     {
         AnnotationRegistry::reset();
         AnnotationRegistry::registerLoader([SilentAutoload::class, 'autoload']);
+    }
+
+    /**
+     * Silence the Yii autoloader
+     *
+     * Silence YiiBase::autoload, which gives a warning for non-existent classes.
+     */
+    public static function registerSilentAutoLoader(): void
+    {
+        spl_autoload_unregister(array('YiiBase','autoload'));
+        spl_autoload_register(function(string $class): bool {
+            $e = error_reporting(E_ALL & ~E_WARNING);
+            $loaded = YiiBase::autoload($class);
+            error_reporting($e);
+
+            return $loaded;
+        });
     }
 }

--- a/src/Dii.php
+++ b/src/Dii.php
@@ -28,6 +28,7 @@ use function is_callable;
 use function is_string;
 use function spl_autoload_register;
 use function spl_autoload_unregister;
+
 use const E_ALL;
 use const E_WARNING;
 
@@ -173,8 +174,8 @@ class Dii extends YiiBase
      */
     public static function registerSilentAutoLoader(): void
     {
-        spl_autoload_unregister(array('YiiBase','autoload'));
-        spl_autoload_register(function(string $class): bool {
+        spl_autoload_unregister(['YiiBase', 'autoload']);
+        spl_autoload_register(static function (string $class): bool {
             $e = error_reporting(E_ALL & ~E_WARNING);
             $loaded = YiiBase::autoload($class);
             error_reporting($e);


### PR DESCRIPTION
Suppresses the `YiiBase::autoload()` warning when a class is not found.