### PR TITLE
Add InjectableModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ class AppModule extends AbstractModule
 }
 ```
 
-The scan is non-recursive and only `*.php` files declaring classes that implement `Koriym\Dii\Injectable` are bound.
+The scan is non-recursive and only top-level `*.php` files declaring classes that implement `Koriym\Dii\Injectable` are bound. Pass each subdirectory explicitly when it should be scanned.
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ As soon as the controller is created, all methods with the `#[Inject]` attribute
 
 ### Bind your injectable controllers
 
-Ray.Di resolves bindings at compile time, so each `Injectable` controller or console command must be **bound explicitly in your module**. If it is not bound, Ray.Di raises `Untargeted` and the request fails fast. Dii no longer auto-binds the concrete class at runtime: that silent fallback was not AOP-compiled, so it behaved differently from an explicit binding and the missing binding went unnoticed (especially at compile time).
+Ray.Di resolves bindings at compile time, so each `Injectable` controller or console command must be **bound in your module**. If it is not bound, Ray.Di raises `Untargeted` and the request fails fast. Dii no longer auto-binds the concrete class at runtime: that silent fallback was not AOP-compiled, so it behaved differently from a module binding and the missing binding went unnoticed (especially at compile time).
 
 ```php
 class AppModule extends AbstractModule
@@ -168,6 +168,31 @@ class AppModule extends AbstractModule
 ```
 
 Also any class created by `Yii:createComponent()` method is worked as well.
+
+## InjectableModule
+
+Use `InjectableModule` to bind every `Injectable` class in flat Yii controller or command directories at compile time:
+
+```php
+use Koriym\Dii\InjectableModule;
+use Ray\Di\AbstractModule;
+
+class AppModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(FooInterface::class)->to(Foo::class);
+
+        // Install this last so explicit bindings above are preserved.
+        $this->install(new InjectableModule([
+            __DIR__ . '/../protected/controllers',
+            __DIR__ . '/../protected/commands',
+        ]));
+    }
+}
+```
+
+The scan is non-recursive and only `*.php` files declaring classes that implement `Koriym\Dii\Injectable` are bound.
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ class AppModule extends AbstractModule
 }
 ```
 
-The scan is non-recursive and only top-level `*.php` files declaring classes that implement `Koriym\Dii\Injectable` are bound. Pass each subdirectory explicitly when it should be scanned.
+The scan is non-recursive and only top-level `*.php` files declaring classes that implement `Koriym\Dii\Injectable` are bound. Pass each subdirectory explicitly when it should be scanned. Abstract classes are skipped because they cannot be instantiated.
+
+A scan path that does not exist throws `Koriym\Dii\Exception\DirectoryNotFound` during module configuration, so a misconfigured path fails fast at compile time.
 
 ## Demo
 

--- a/src/Exception/DirectoryNotFound.php
+++ b/src/Exception/DirectoryNotFound.php
@@ -9,6 +9,6 @@ use RuntimeException;
 /**
  * Thrown when an injectable scan directory does not exist
  */
-final class DirectoryNotFoundException extends RuntimeException
+final class DirectoryNotFound extends RuntimeException
 {
 }

--- a/src/Exception/DirectoryNotFoundException.php
+++ b/src/Exception/DirectoryNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when an injectable scan directory does not exist
+ */
+final class DirectoryNotFoundException extends RuntimeException
+{
+}

--- a/src/InjectableModule.php
+++ b/src/InjectableModule.php
@@ -4,37 +4,55 @@ declare(strict_types=1);
 
 namespace Koriym\Dii;
 
-use Koriym\Dii\Exception\DirectoryNotFoundException;
+use Koriym\Dii\Exception\DirectoryNotFound;
 use Ray\Di\AbstractModule;
 use Ray\Di\Name;
+use ReflectionClass;
+use ReflectionProperty;
 
+use function array_key_exists;
+use function array_keys;
+use function array_slice;
 use function class_exists;
 use function class_implements;
 use function count;
+use function explode;
 use function file_get_contents;
 use function glob;
+use function implode;
 use function in_array;
 use function is_array;
 use function is_dir;
 use function is_string;
+use function ltrim;
 use function rtrim;
 use function sprintf;
+use function strrpos;
+use function substr;
 use function token_get_all;
 
 use const DIRECTORY_SEPARATOR;
+use const T_AS;
 use const T_CLASS;
 use const T_COMMENT;
 use const T_DOC_COMMENT;
 use const T_DOUBLE_COLON;
+use const T_EXTENDS;
+use const T_IMPLEMENTS;
 use const T_NAME_FULLY_QUALIFIED;
 use const T_NAME_QUALIFIED;
+use const T_NAME_RELATIVE;
 use const T_NAMESPACE;
 use const T_NEW;
 use const T_NS_SEPARATOR;
+use const T_OPEN_TAG;
 use const T_STRING;
+use const T_USE;
 use const T_WHITESPACE;
 
 /**
+ * @psalm-type ParsedClass = array{class: string, file: string, extends: ?string, implements: list<string>}
+ *
  * Binds concrete Injectable classes discovered from flat Yii directories.
  */
 final class InjectableModule extends AbstractModule
@@ -57,49 +75,47 @@ final class InjectableModule extends AbstractModule
      */
     protected function configure()
     {
+        $classes = [];
         foreach ($this->directories as $directory) {
-            $this->bindInjectablesInDirectory($directory);
+            foreach ($this->parseClassesInDirectory($directory) as $class => $metadata) {
+                $classes[$class] = $metadata;
+            }
+        }
+
+        $injectableClasses = $this->findInjectableClasses($classes);
+        $loaded = [];
+        foreach (array_keys($injectableClasses) as $class) {
+            $this->loadAndBindCandidate($class, $classes, $injectableClasses, $loaded);
         }
     }
 
-    private function bindInjectablesInDirectory(string $directory): void
+    /**
+     * @return array<string, ParsedClass>
+     */
+    private function parseClassesInDirectory(string $directory): array
     {
         if (! is_dir($directory)) {
-            throw new DirectoryNotFoundException(sprintf('Directory not found: %s', $directory));
+            throw new DirectoryNotFound(sprintf('Directory not found: %s', $directory));
         }
 
         $files = glob(rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*.php');
         if (! is_array($files)) {
-            return;
+            return [];
         }
 
+        $classes = [];
         foreach ($files as $file) {
-            $class = $this->extractClass($file);
-            if ($class === null) {
-                continue;
+            foreach ($this->parseClassesInFile($file) as $metadata) {
+                $classes[$metadata['class']] = $metadata;
             }
-
-            require_once $file;
-
-            if (! class_exists($class)) {
-                continue;
-            }
-
-            if (! $this->implementsInjectable($class)) {
-                continue;
-            }
-
-            if ($this->isBound($class)) {
-                continue;
-            }
-
-            $this->bind($class);
         }
+
+        return $classes;
     }
 
     private function implementsInjectable(string $class): bool
     {
-        $interfaces = class_implements($class);
+        $interfaces = class_implements($class, false);
         if (! is_array($interfaces)) {
             return false;
         }
@@ -110,26 +126,136 @@ final class InjectableModule extends AbstractModule
     private function isBound(string $class): bool
     {
         $index = $class . '-' . Name::ANY;
-        if (isset($this->getContainer()->getContainer()[$index])) {
+        foreach ($this->moduleChain() as $module) {
+            if (! array_key_exists($index, $module->getContainer()->getContainer())) {
+                continue;
+            }
+
             return true;
         }
 
-        if (! $this->lastModule instanceof AbstractModule) {
+        return false;
+    }
+
+    /**
+     * @param array<string, ParsedClass> $classes
+     *
+     * @return array<string, true>
+     */
+    private function findInjectableClasses(array $classes): array
+    {
+        $injectableClasses = [];
+        $changed = true;
+        while ($changed) {
+            $changed = false;
+            foreach ($classes as $class => $metadata) {
+                if (isset($injectableClasses[$class])) {
+                    continue;
+                }
+
+                if ($this->explicitlyImplementsInjectable($metadata)) {
+                    $injectableClasses[$class] = true;
+                    $changed = true;
+
+                    continue;
+                }
+
+                if (! $this->extendsKnownInjectable($metadata, $injectableClasses)) {
+                    continue;
+                }
+
+                $injectableClasses[$class] = true;
+                $changed = true;
+            }
+        }
+
+        return $injectableClasses;
+    }
+
+    /** @param array{class: string, file: string, extends: ?string, implements: list<string>} $metadata */
+    private function explicitlyImplementsInjectable(array $metadata): bool
+    {
+        return in_array(Injectable::class, $metadata['implements'], true);
+    }
+
+    /**
+     * @param array{class: string, file: string, extends: ?string, implements: list<string>} $metadata
+     * @param array<string,true>                                                             $injectableClasses
+     */
+    private function extendsKnownInjectable(array $metadata, array $injectableClasses): bool
+    {
+        $parent = $metadata['extends'];
+        if ($parent === null) {
             return false;
         }
 
-        return isset($this->lastModule->getContainer()->getContainer()[$index]);
+        if (isset($injectableClasses[$parent])) {
+            return true;
+        }
+
+        if (! class_exists($parent, false)) {
+            return false;
+        }
+
+        return $this->implementsInjectable($parent);
     }
 
-    private function extractClass(string $file): ?string
+    /**
+     * @param array<string, ParsedClass> $classes
+     * @param array<string, true>        $injectableClasses
+     * @param array<string, true>        $loaded
+     */
+    private function loadAndBindCandidate(string $class, array $classes, array $injectableClasses, array &$loaded): void
+    {
+        if (isset($loaded[$class])) {
+            return;
+        }
+
+        if (! isset($classes[$class])) {
+            return;
+        }
+
+        $metadata = $classes[$class];
+        $parent = $metadata['extends'];
+        if ($parent !== null && isset($injectableClasses[$parent])) {
+            $this->loadAndBindCandidate($parent, $classes, $injectableClasses, $loaded);
+        }
+
+        require_once $metadata['file'];
+        $loaded[$class] = true;
+        if (! class_exists($class, false)) {
+            return;
+        }
+
+        if (! $this->implementsInjectable($class)) {
+            return;
+        }
+
+        if (! (new ReflectionClass($class))->isInstantiable()) {
+            return;
+        }
+
+        if ($this->isBound($class)) {
+            return;
+        }
+
+        $this->bind($class);
+    }
+
+    /**
+     * @return list<ParsedClass>
+     */
+    private function parseClassesInFile(string $file): array
     {
         $source = file_get_contents($file);
         if (! is_string($source)) {
-            return null;
+            return [];
         }
 
         $tokens = token_get_all($source);
         $namespace = '';
+        $uses = [];
+        $classes = [];
         $count = count($tokens);
         for ($i = 0; $i < $count; $i++) {
             $token = $tokens[$i];
@@ -139,6 +265,16 @@ final class InjectableModule extends AbstractModule
 
             if ($token[0] === T_NAMESPACE) {
                 $namespace = $this->readNamespace($tokens, $i + 1);
+                $uses = [];
+
+                continue;
+            }
+
+            if ($token[0] === T_USE && $classes === [] && $this->isNamespaceUse($tokens, $i)) {
+                foreach ($this->readUseAliases($tokens, $i + 1) as $alias => $class) {
+                    $uses[$alias] = $class;
+                }
+
                 continue;
             }
 
@@ -150,19 +286,15 @@ final class InjectableModule extends AbstractModule
                 continue;
             }
 
-            $class = $this->readClassName($tokens, $i + 1);
-            if ($class === null) {
-                return null;
+            $metadata = $this->readClassMetadata($tokens, $i + 1, $namespace, $uses, $file);
+            if ($metadata === null) {
+                continue;
             }
 
-            if ($namespace === '') {
-                return $class;
-            }
-
-            return $namespace . '\\' . $class;
+            $classes[] = $metadata;
         }
 
-        return null;
+        return $classes;
     }
 
     /**
@@ -194,8 +326,33 @@ final class InjectableModule extends AbstractModule
 
     /**
      * @param array<int, array{0:int, 1:string, 2:int}|string> $tokens
+     * @param array<string, string>                            $uses
+     *
+     * @return array{class: string, file: string, extends: ?string, implements: list<string>}|null
      */
-    private function readClassName(array $tokens, int $offset): ?string
+    private function readClassMetadata(array $tokens, int $offset, string $namespace, array $uses, string $file): ?array
+    {
+        $className = $this->readClassName($tokens, $offset);
+        if ($className === null) {
+            return null;
+        }
+
+        [$extends, $implements] = $this->readClassRelationships($tokens, $className['index'] + 1, $namespace, $uses);
+
+        return [
+            'class' => $this->resolveDeclaredClassName($className['name'], $namespace),
+            'file' => $file,
+            'extends' => $extends,
+            'implements' => $implements,
+        ];
+    }
+
+    /**
+     * @param array<int, array{0:int, 1:string, 2:int}|string> $tokens
+     *
+     * @return array{name: string, index: int}|null
+     */
+    private function readClassName(array $tokens, int $offset): ?array
     {
         $count = count($tokens);
         for ($i = $offset; $i < $count; $i++) {
@@ -209,13 +366,196 @@ final class InjectableModule extends AbstractModule
             }
 
             if ($token[0] === T_STRING) {
-                return $token[1];
+                return ['name' => $token[1], 'index' => $i];
             }
 
             return null;
         }
 
         return null;
+    }
+
+    /**
+     * @param array<int, array{0:int, 1:string, 2:int}|string> $tokens
+     * @param array<string, string>                            $uses
+     *
+     * @return array{0: ?string, 1: list<string>}
+     */
+    private function readClassRelationships(array $tokens, int $offset, string $namespace, array $uses): array
+    {
+        $extends = null;
+        $implements = [];
+        $count = count($tokens);
+        for ($i = $offset; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if ($token === '{') {
+                return [$extends, $implements];
+            }
+
+            if (! is_array($token)) {
+                continue;
+            }
+
+            if ($token[0] === T_EXTENDS) {
+                $name = $this->readName($tokens, $i + 1);
+                if ($name === null) {
+                    continue;
+                }
+
+                $extends = $this->resolveName($name['name'], $namespace, $uses);
+                $i = $name['index'];
+
+                continue;
+            }
+
+            if ($token[0] !== T_IMPLEMENTS) {
+                continue;
+            }
+
+            $implements = $this->readImplementedNames($tokens, $i + 1, $namespace, $uses);
+
+            return [$extends, $implements];
+        }
+
+        return [$extends, $implements];
+    }
+
+    /**
+     * @param array<int, array{0:int, 1:string, 2:int}|string> $tokens
+     *
+     * @return array{name: string, index: int}|null
+     */
+    private function readName(array $tokens, int $offset): ?array
+    {
+        $name = '';
+        $count = count($tokens);
+        for ($i = $offset; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (is_array($token) && $token[0] === T_WHITESPACE && $name === '') {
+                continue;
+            }
+
+            if (is_array($token) && $this->isNameToken($token[0])) {
+                $name .= $token[1];
+
+                continue;
+            }
+
+            if ($name === '') {
+                return null;
+            }
+
+            return ['name' => $name, 'index' => $i - 1];
+        }
+
+        if ($name === '') {
+            return null;
+        }
+
+        return ['name' => $name, 'index' => $count - 1];
+    }
+
+    /**
+     * @param array<int, array{0:int, 1:string, 2:int}|string> $tokens
+     * @param array<string, string>                            $uses
+     *
+     * @return list<string>
+     */
+    private function readImplementedNames(array $tokens, int $offset, string $namespace, array $uses): array
+    {
+        $implements = [];
+        $name = '';
+        $count = count($tokens);
+        for ($i = $offset; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if ($token === '{') {
+                $this->addResolvedName($implements, $name, $namespace, $uses);
+
+                return $implements;
+            }
+
+            if ($token === ',') {
+                $this->addResolvedName($implements, $name, $namespace, $uses);
+                $name = '';
+
+                continue;
+            }
+
+            if (! is_array($token)) {
+                continue;
+            }
+
+            if ($token[0] === T_WHITESPACE) {
+                continue;
+            }
+
+            if (! $this->isNameToken($token[0])) {
+                continue;
+            }
+
+            $name .= $token[1];
+        }
+
+        $this->addResolvedName($implements, $name, $namespace, $uses);
+
+        return $implements;
+    }
+
+    /**
+     * @param array<int, array{0:int, 1:string, 2:int}|string> $tokens
+     *
+     * @return array<string, string>
+     */
+    private function readUseAliases(array $tokens, int $offset): array
+    {
+        $uses = [];
+        $name = '';
+        $alias = '';
+        $readingAlias = false;
+        $count = count($tokens);
+        for ($i = $offset; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if ($token === ';') {
+                $this->addUseAlias($uses, $name, $alias);
+
+                return $uses;
+            }
+
+            if ($token === ',') {
+                $this->addUseAlias($uses, $name, $alias);
+                $name = '';
+                $alias = '';
+                $readingAlias = false;
+
+                continue;
+            }
+
+            if (! is_array($token)) {
+                continue;
+            }
+
+            if ($token[0] === T_AS) {
+                $readingAlias = true;
+
+                continue;
+            }
+
+            if (! $this->isNameToken($token[0])) {
+                continue;
+            }
+
+            if ($readingAlias) {
+                $alias .= $token[1];
+
+                continue;
+            }
+
+            $name .= $token[1];
+        }
+
+        $this->addUseAlias($uses, $name, $alias);
+
+        return $uses;
     }
 
     /**
@@ -239,8 +579,134 @@ final class InjectableModule extends AbstractModule
         return true;
     }
 
+    /**
+     * @param array<int, array{0:int, 1:string, 2:int}|string> $tokens
+     */
+    private function isNamespaceUse(array $tokens, int $useIndex): bool
+    {
+        for ($i = $useIndex - 1; $i >= 0; $i--) {
+            $token = $tokens[$i];
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            if (is_array($token) && $token[0] === T_OPEN_TAG) {
+                return true;
+            }
+
+            return $token === ';' || $token === '{';
+        }
+
+        return true;
+    }
+
     private function isNameToken(int $token): bool
     {
-        return in_array($token, [T_STRING, T_NS_SEPARATOR, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED], true);
+        return in_array($token, [T_STRING, T_NS_SEPARATOR, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED, T_NAME_RELATIVE], true);
+    }
+
+    private function resolveDeclaredClassName(string $class, string $namespace): string
+    {
+        if ($namespace === '') {
+            return $class;
+        }
+
+        return $namespace . '\\' . $class;
+    }
+
+    /**
+     * @param array<string, string> $uses
+     */
+    private function resolveName(string $name, string $namespace, array $uses): string
+    {
+        if ($name[0] === '\\') {
+            return ltrim($name, '\\');
+        }
+
+        $parts = explode('\\', $name);
+        $alias = $parts[0];
+        if (isset($uses[$alias])) {
+            if (count($parts) === 1) {
+                return $uses[$alias];
+            }
+
+            return $uses[$alias] . '\\' . implode('\\', array_slice($parts, 1));
+        }
+
+        if ($namespace === '') {
+            return $name;
+        }
+
+        return $namespace . '\\' . $name;
+    }
+
+    /**
+     * @param list<string>          $names
+     * @param array<string, string> $uses
+     *
+     * @psalm-param-out list<string> $names
+     */
+    private function addResolvedName(array &$names, string $name, string $namespace, array $uses): void
+    {
+        if ($name === '') {
+            return;
+        }
+
+        $names[] = $this->resolveName($name, $namespace, $uses);
+    }
+
+    /**
+     * @param array<string, string> $uses
+     *
+     * @psalm-param-out array<string, string> $uses
+     */
+    private function addUseAlias(array &$uses, string $name, string $alias): void
+    {
+        if ($name === '') {
+            return;
+        }
+
+        $class = ltrim($name, '\\');
+        $uses[$alias !== '' ? $alias : $this->shortName($class)] = $class;
+    }
+
+    private function shortName(string $class): string
+    {
+        $position = strrpos($class, '\\');
+        if ($position === false) {
+            return $class;
+        }
+
+        return substr($class, $position + 1);
+    }
+
+    /**
+     * Ray.Di has no public is-bound API. Container::getContainer() is public,
+     * but its string keys are Ray.Di's internal binding convention.
+     *
+     * @return list<AbstractModule>
+     */
+    private function moduleChain(): array
+    {
+        $modules = [$this];
+        $module = $this->lastModule;
+        while ($module instanceof AbstractModule) {
+            $modules[] = $module;
+            $module = $this->readLastModule($module);
+        }
+
+        return $modules;
+    }
+
+    private function readLastModule(AbstractModule $module): ?AbstractModule
+    {
+        $property = new ReflectionProperty(AbstractModule::class, 'lastModule');
+        $property->setAccessible(true);
+        $lastModule = $property->getValue($module);
+        if (! $lastModule instanceof AbstractModule) {
+            return null;
+        }
+
+        return $lastModule;
     }
 }

--- a/src/InjectableModule.php
+++ b/src/InjectableModule.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii;
+
+use Koriym\Dii\Exception\DirectoryNotFoundException;
+use Ray\Di\AbstractModule;
+use Ray\Di\Name;
+
+use function class_exists;
+use function class_implements;
+use function count;
+use function file_get_contents;
+use function glob;
+use function in_array;
+use function is_array;
+use function is_dir;
+use function is_string;
+use function rtrim;
+use function sprintf;
+use function token_get_all;
+
+use const DIRECTORY_SEPARATOR;
+use const T_CLASS;
+use const T_COMMENT;
+use const T_DOC_COMMENT;
+use const T_DOUBLE_COLON;
+use const T_NAME_FULLY_QUALIFIED;
+use const T_NAME_QUALIFIED;
+use const T_NAMESPACE;
+use const T_NEW;
+use const T_NS_SEPARATOR;
+use const T_STRING;
+use const T_WHITESPACE;
+
+/**
+ * Binds concrete Injectable classes discovered from flat Yii directories.
+ */
+final class InjectableModule extends AbstractModule
+{
+    /** @var string[] */
+    private array $directories;
+
+    /**
+     * @param string[] $directories
+     */
+    public function __construct(array $directories, ?AbstractModule $module = null)
+    {
+        $this->directories = $directories;
+
+        parent::__construct($module);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        foreach ($this->directories as $directory) {
+            $this->bindInjectablesInDirectory($directory);
+        }
+    }
+
+    private function bindInjectablesInDirectory(string $directory): void
+    {
+        if (! is_dir($directory)) {
+            throw new DirectoryNotFoundException(sprintf('Directory not found: %s', $directory));
+        }
+
+        $files = glob(rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*.php');
+        if (! is_array($files)) {
+            return;
+        }
+
+        foreach ($files as $file) {
+            $class = $this->extractClass($file);
+            if ($class === null) {
+                continue;
+            }
+
+            require_once $file;
+
+            if (! class_exists($class)) {
+                continue;
+            }
+
+            if (! $this->implementsInjectable($class)) {
+                continue;
+            }
+
+            if ($this->isBound($class)) {
+                continue;
+            }
+
+            $this->bind($class);
+        }
+    }
+
+    private function implementsInjectable(string $class): bool
+    {
+        $interfaces = class_implements($class);
+        if (! is_array($interfaces)) {
+            return false;
+        }
+
+        return in_array(Injectable::class, $interfaces, true);
+    }
+
+    private function isBound(string $class): bool
+    {
+        $index = $class . '-' . Name::ANY;
+        if (isset($this->getContainer()->getContainer()[$index])) {
+            return true;
+        }
+
+        if (! $this->lastModule instanceof AbstractModule) {
+            return false;
+        }
+
+        return isset($this->lastModule->getContainer()->getContainer()[$index]);
+    }
+
+    private function extractClass(string $file): ?string
+    {
+        $source = file_get_contents($file);
+        if (! is_string($source)) {
+            return null;
+        }
+
+        $tokens = token_get_all($source);
+        $namespace = '';
+        $count = count($tokens);
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (! is_array($token)) {
+                continue;
+            }
+
+            if ($token[0] === T_NAMESPACE) {
+                $namespace = $this->readNamespace($tokens, $i + 1);
+                continue;
+            }
+
+            if ($token[0] !== T_CLASS) {
+                continue;
+            }
+
+            if (! $this->isClassDeclaration($tokens, $i)) {
+                continue;
+            }
+
+            $class = $this->readClassName($tokens, $i + 1);
+            if ($class === null) {
+                return null;
+            }
+
+            if ($namespace === '') {
+                return $class;
+            }
+
+            return $namespace . '\\' . $class;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, array{0:int, 1:string, 2:int}|string> $tokens
+     */
+    private function readNamespace(array $tokens, int $offset): string
+    {
+        $namespace = '';
+        $count = count($tokens);
+        for ($i = $offset; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if ($token === ';' || $token === '{') {
+                return $namespace;
+            }
+
+            if (! is_array($token)) {
+                continue;
+            }
+
+            if (! $this->isNameToken($token[0])) {
+                continue;
+            }
+
+            $namespace .= $token[1];
+        }
+
+        return $namespace;
+    }
+
+    /**
+     * @param array<int, array{0:int, 1:string, 2:int}|string> $tokens
+     */
+    private function readClassName(array $tokens, int $offset): ?string
+    {
+        $count = count($tokens);
+        for ($i = $offset; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (! is_array($token)) {
+                continue;
+            }
+
+            if ($token[0] === T_WHITESPACE) {
+                continue;
+            }
+
+            if ($token[0] === T_STRING) {
+                return $token[1];
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, array{0:int, 1:string, 2:int}|string> $tokens
+     */
+    private function isClassDeclaration(array $tokens, int $classIndex): bool
+    {
+        for ($i = $classIndex - 1; $i >= 0; $i--) {
+            $token = $tokens[$i];
+            if (! is_array($token)) {
+                return true;
+            }
+
+            if (in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            return ! in_array($token[0], [T_NEW, T_DOUBLE_COLON], true);
+        }
+
+        return true;
+    }
+
+    private function isNameToken(int $token): bool
+    {
+        return in_array($token, [T_STRING, T_NS_SEPARATOR, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED], true);
+    }
+}

--- a/tests/Fake/InjectableModuleFake/AbstractInjectable.php
+++ b/tests/Fake/InjectableModuleFake/AbstractInjectable.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake;
+
+use Koriym\Dii\Injectable;
+
+abstract class AbstractInjectable implements Injectable
+{
+}

--- a/tests/Fake/InjectableModuleFake/AlreadyBoundInjectable.php
+++ b/tests/Fake/InjectableModuleFake/AlreadyBoundInjectable.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake;
+
+use Koriym\Dii\Injectable;
+
+class AlreadyBoundInjectable implements Injectable
+{
+}

--- a/tests/Fake/InjectableModuleFake/AopInterceptor.php
+++ b/tests/Fake/InjectableModuleFake/AopInterceptor.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake;
+
+use Ray\Aop\MethodInterceptor;
+use Ray\Aop\MethodInvocation;
+
+class AopInterceptor implements MethodInterceptor
+{
+    public function invoke(MethodInvocation $invocation)
+    {
+        $target = $invocation->getThis();
+        if ($target instanceof AopScannedInjectable) {
+            $target->intercepted = true;
+        }
+
+        return $invocation->proceed();
+    }
+}

--- a/tests/Fake/InjectableModuleFake/AopScannedInjectable.php
+++ b/tests/Fake/InjectableModuleFake/AopScannedInjectable.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake;
+
+use Koriym\Dii\Injectable;
+
+class AopScannedInjectable implements Injectable
+{
+    public bool $intercepted = false;
+
+    public function actionIndex(): string
+    {
+        return '';
+    }
+}

--- a/tests/Fake/InjectableModuleFake/ChildInjectable.php
+++ b/tests/Fake/InjectableModuleFake/ChildInjectable.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake;
+
+class ChildInjectable extends AlreadyBoundInjectable
+{
+}

--- a/tests/Fake/InjectableModuleFake/ConcreteFromAbstractInjectable.php
+++ b/tests/Fake/InjectableModuleFake/ConcreteFromAbstractInjectable.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake;
+
+class ConcreteFromAbstractInjectable extends AbstractInjectable
+{
+}

--- a/tests/Fake/InjectableModuleFake/NoClass.php
+++ b/tests/Fake/InjectableModuleFake/NoClass.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake;
+
+const NO_CLASS_FILE = true;

--- a/tests/Fake/InjectableModuleFake/PlainClass.php
+++ b/tests/Fake/InjectableModuleFake/PlainClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake;
+
+class PlainClass
+{
+}

--- a/tests/Fake/InjectableModuleFake/Replacement/AlreadyBoundReplacement.php
+++ b/tests/Fake/InjectableModuleFake/Replacement/AlreadyBoundReplacement.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake\Replacement;
+
+use Koriym\Dii\InjectableModuleFake\AlreadyBoundInjectable;
+
+class AlreadyBoundReplacement extends AlreadyBoundInjectable
+{
+}

--- a/tests/Fake/InjectableModuleFake/ScannedInjectable.php
+++ b/tests/Fake/InjectableModuleFake/ScannedInjectable.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake;
+
+use Koriym\Dii\Injectable;
+
+class ScannedInjectable implements Injectable
+{
+}

--- a/tests/Fake/InjectableModuleFake/SideEffectClass.php
+++ b/tests/Fake/InjectableModuleFake/SideEffectClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake;
+
+use Koriym\Dii\InjectableModuleFake\Support\SideEffectFlag;
+
+SideEffectFlag::$loaded = true;
+
+class SideEffectClass
+{
+}

--- a/tests/Fake/InjectableModuleFake/Support/SideEffectFlag.php
+++ b/tests/Fake/InjectableModuleFake/Support/SideEffectFlag.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii\InjectableModuleFake\Support;
+
+class SideEffectFlag
+{
+    public static bool $loaded = false;
+}

--- a/tests/UnitTest/InjectableModuleTest.php
+++ b/tests/UnitTest/InjectableModuleTest.php
@@ -4,16 +4,26 @@ declare(strict_types=1);
 
 namespace Koriym\Dii;
 
-use Koriym\Dii\Exception\DirectoryNotFoundException;
+use Koriym\Dii\Exception\DirectoryNotFound;
+use Koriym\Dii\InjectableModuleFake\AbstractInjectable;
 use Koriym\Dii\InjectableModuleFake\AlreadyBoundInjectable;
+use Koriym\Dii\InjectableModuleFake\AopInterceptor;
+use Koriym\Dii\InjectableModuleFake\AopScannedInjectable;
+use Koriym\Dii\InjectableModuleFake\ChildInjectable;
+use Koriym\Dii\InjectableModuleFake\ConcreteFromAbstractInjectable;
 use Koriym\Dii\InjectableModuleFake\PlainClass;
 use Koriym\Dii\InjectableModuleFake\Replacement\AlreadyBoundReplacement;
 use Koriym\Dii\InjectableModuleFake\ScannedInjectable;
+use Koriym\Dii\InjectableModuleFake\SideEffectClass;
+use Koriym\Dii\InjectableModuleFake\Support\SideEffectFlag;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
 use Ray\Di\Name;
 
+use function class_exists;
 use function dirname;
+use function sys_get_temp_dir;
 
 final class InjectableModuleTest extends TestCase
 {
@@ -26,6 +36,7 @@ final class InjectableModuleTest extends TestCase
 
         $this->assertArrayHasKey($this->bindingKey(ScannedInjectable::class), $container->getContainer());
         $this->assertInstanceOf(ScannedInjectable::class, $container->getInstance(ScannedInjectable::class));
+        $this->assertInstanceOf(ChildInjectable::class, $container->getInstance(ChildInjectable::class));
     }
 
     public function testClassesWithoutInjectableAreSkipped(): void
@@ -33,6 +44,26 @@ final class InjectableModuleTest extends TestCase
         $module = new InjectableModule([self::FAKE_DIR]);
 
         $this->assertArrayNotHasKey($this->bindingKey(PlainClass::class), $module->getContainer()->getContainer());
+    }
+
+    public function testAbstractInjectableClassesAreSkippedButConcreteSubclassesAreBound(): void
+    {
+        $module = new InjectableModule([self::FAKE_DIR]);
+        $container = $module->getContainer();
+
+        $this->assertArrayNotHasKey($this->bindingKey(AbstractInjectable::class), $container->getContainer());
+        $this->assertArrayHasKey($this->bindingKey(ConcreteFromAbstractInjectable::class), $container->getContainer());
+        $this->assertInstanceOf(ConcreteFromAbstractInjectable::class, $container->getInstance(ConcreteFromAbstractInjectable::class));
+    }
+
+    public function testNonInjectableFilesAreNotLoaded(): void
+    {
+        SideEffectFlag::$loaded = false;
+
+        new InjectableModule([self::FAKE_DIR]);
+
+        $this->assertFalse(SideEffectFlag::$loaded);
+        $this->assertFalse(class_exists(SideEffectClass::class, false));
     }
 
     public function testAlreadyBoundClassesAreNotOverriddenWhenInstalledLast(): void
@@ -65,9 +96,29 @@ final class InjectableModuleTest extends TestCase
         $this->assertInstanceOf(AlreadyBoundReplacement::class, $instance);
     }
 
+    public function testScannedInjectableIsAopWoven(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure()
+            {
+                $this->bindInterceptor(
+                    $this->matcher->any(),
+                    $this->matcher->startsWith('actionIndex'),
+                    [AopInterceptor::class]
+                );
+                $this->install(new InjectableModule([InjectableModuleTest::FAKE_DIR]));
+            }
+        };
+
+        $target = (new Injector($module, sys_get_temp_dir()))->getInstance(AopScannedInjectable::class);
+        $target->actionIndex();
+
+        $this->assertTrue($target->intercepted);
+    }
+
     public function testDirectoryNotFound(): void
     {
-        $this->expectException(DirectoryNotFoundException::class);
+        $this->expectException(DirectoryNotFound::class);
 
         new InjectableModule([dirname(__DIR__) . '/Fake/InjectableModuleFakeMissing']);
     }

--- a/tests/UnitTest/InjectableModuleTest.php
+++ b/tests/UnitTest/InjectableModuleTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\Dii;
+
+use Koriym\Dii\Exception\DirectoryNotFoundException;
+use Koriym\Dii\InjectableModuleFake\AlreadyBoundInjectable;
+use Koriym\Dii\InjectableModuleFake\PlainClass;
+use Koriym\Dii\InjectableModuleFake\Replacement\AlreadyBoundReplacement;
+use Koriym\Dii\InjectableModuleFake\ScannedInjectable;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\AbstractModule;
+use Ray\Di\Name;
+
+use function dirname;
+
+final class InjectableModuleTest extends TestCase
+{
+    public const FAKE_DIR = __DIR__ . '/../Fake/InjectableModuleFake';
+
+    public function testInjectableClassesGetBound(): void
+    {
+        $module = new InjectableModule([self::FAKE_DIR]);
+        $container = $module->getContainer();
+
+        $this->assertArrayHasKey($this->bindingKey(ScannedInjectable::class), $container->getContainer());
+        $this->assertInstanceOf(ScannedInjectable::class, $container->getInstance(ScannedInjectable::class));
+    }
+
+    public function testClassesWithoutInjectableAreSkipped(): void
+    {
+        $module = new InjectableModule([self::FAKE_DIR]);
+
+        $this->assertArrayNotHasKey($this->bindingKey(PlainClass::class), $module->getContainer()->getContainer());
+    }
+
+    public function testAlreadyBoundClassesAreNotOverriddenWhenInstalledLast(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure()
+            {
+                $this->bind(AlreadyBoundInjectable::class)->to(AlreadyBoundReplacement::class);
+                $this->install(new InjectableModule([InjectableModuleTest::FAKE_DIR]));
+            }
+        };
+
+        $instance = $module->getContainer()->getInstance(AlreadyBoundInjectable::class);
+
+        $this->assertInstanceOf(AlreadyBoundReplacement::class, $instance);
+    }
+
+    public function testAlreadyBoundClassesAreNotOverriddenFromPreviousModule(): void
+    {
+        $explicitModule = new class extends AbstractModule {
+            protected function configure()
+            {
+                $this->bind(AlreadyBoundInjectable::class)->to(AlreadyBoundReplacement::class);
+            }
+        };
+        $module = new InjectableModule([self::FAKE_DIR], $explicitModule);
+
+        $instance = $module->getContainer()->getInstance(AlreadyBoundInjectable::class);
+
+        $this->assertInstanceOf(AlreadyBoundReplacement::class, $instance);
+    }
+
+    public function testDirectoryNotFound(): void
+    {
+        $this->expectException(DirectoryNotFoundException::class);
+
+        new InjectableModule([dirname(__DIR__) . '/Fake/InjectableModuleFakeMissing']);
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function bindingKey(string $class): string
+    {
+        return $class . '-' . Name::ANY;
+    }
+}


### PR DESCRIPTION
## Summary

Add `Koriym\Dii\InjectableModule`, a `Ray\Di\AbstractModule` that bulk-binds `Injectable` controllers/commands discovered from flat Yii directories.

Dii now requires an `Injectable` controller or console command to be bound explicitly via untargeted binding (`$this->bind(SiteController::class)`). The previous runtime fallback that auto-bound unbound concrete classes (`catch (Unbound) { new Bind(...); retry }`) was removed because it was **not** AOP-compiled and therefore behaved differently from an explicit binding — the missing binding went unnoticed, especially at compile time with Ray.Compiler.

`InjectableModule` restores the convenience of bulk binding **without** that defect: it binds during `configure()` (compile time), so the bindings **are** AOP-compiled.

## Behavior

- Constructor takes an array of directories: `new InjectableModule([__DIR__ . '/protected/controllers', __DIR__ . '/protected/commands'])`.
- In `configure()`, scans those directories (non-recursive, `*.php`), extracts the declared class via the tokenizer, and binds **only** classes that implement `Koriym\Dii\Injectable` and are **not already bound**, via untargeted `$this->bind($class)`.
- Skipping already-bound classes preserves explicit bindings (including `->to()` ones). Both protection paths are covered:
  - **Installed last** (`$this->install(new InjectableModule(...))`) — `Container::merge()`'s `+=` keeps the pre-existing explicit binding.
  - **Passed as previous module** (`new InjectableModule([...], $explicitModule)`) — detected via `lastModule` inside `isBound()`, since the previous module is not yet merged into this module's container during `configure()`.
- A missing directory throws the dedicated `DirectoryNotFoundException`.

## Changes

- `src/InjectableModule.php` — the module
- `src/Exception/DirectoryNotFoundException.php` — dedicated domain exception
- `tests/UnitTest/InjectableModuleTest.php` + `tests/Fake/InjectableModuleFake/*` — tests using real Fake fixtures (no mocks)
- `README.md` — InjectableModule usage section

## Checks

- ✅ `phpunit` (Unit + Integration): 20 tests, 30 assertions
- ✅ `phpcs --standard=./phpcs.xml src tests`: no errors
- ✅ `psalm --show-info=false`: no errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added InjectableModule to automatically discover and bind Injectable controllers and commands from specified directories during compilation.

* **Documentation**
  * Updated binding guidance clarifying that Injectable classes require explicit binding; documented the new InjectableModule with configuration examples and usage guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->